### PR TITLE
demoPath 'no such file or directory' related fixes

### DIFF
--- a/src/renderer/components/DemoList.vue
+++ b/src/renderer/components/DemoList.vue
@@ -3,7 +3,7 @@
     
     <h2 class="pageTitle">Odamex Demos 
       <b-button size="sm" variant="primary" @click="retrieveDemos()" class="float-right mt-1"><font-awesome-icon icon="sync" /> Refresh</b-button>
-      </h2>
+    </h2>
 
     <p>Demo count: {{demoList.length}}</p>
 
@@ -114,7 +114,7 @@
         this.demoList = []
 
         this.demoList = await demoparser.getDemosfromPath(this.$store.state.demoPath)
-        this.tableState = (this.demoList.length > 0) ? 'ok' : 'loading'
+        this.tableState = 'ok'
            
       },
       showDemoInfo(demo){

--- a/src/renderer/components/settings/DemoSettings.vue
+++ b/src/renderer/components/settings/DemoSettings.vue
@@ -65,8 +65,10 @@ export default {
     async openBrowseFolderWindow(){
 
       let chosenPath = await dialog.showOpenDialog({properties: ['openDirectory']})
-
-      this.$store.dispatch('setDefaultDemosFolder', chosenPath.filePaths[0])
+  
+      if (!chosenPath.canceled){
+        this.$store.dispatch('setDefaultDemosFolder', chosenPath.filePaths[0])
+      }
 
     },
 

--- a/src/renderer/components/settings/WADSSettings.vue
+++ b/src/renderer/components/settings/WADSSettings.vue
@@ -30,8 +30,10 @@ export default {
     async openBrowseFolderWindow(){
 
       let chosenPath = await dialog.showOpenDialog({properties: ['openDirectory']})
-        
-      this.$store.dispatch('setDefaultWADsFolder', chosenPath.filePaths[0])
+
+      if (!chosenPath.canceled){
+        this.$store.dispatch('setDefaultWADsFolder', chosenPath.filePaths[0])
+      }
 
     }
   }

--- a/src/renderer/libs/demoparser.js
+++ b/src/renderer/libs/demoparser.js
@@ -10,6 +10,7 @@ let demoparser = {
     const path = require('path');
 
     let demos = []
+    let defaultPath = path.resolve('demos')
 
     try {
 
@@ -22,7 +23,12 @@ let demoparser = {
 
     } catch (err) {
 
-      console.error(err)
+      //create the default demoPath dir if it does not exist
+      if(err.message.includes("no such file or directory, scandir '" + defaultPath)){
+        fs.promises.mkdir(defaultPath)
+      } else {
+        console.error(err)
+      }
 
     }
 

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -15,7 +15,7 @@ import modules from './modules'
 //set paths
 const binPath = path.join('./', 'odamexbin')
 const wadPath = path.join('./', 'wads')
-const demoPath = path.join('./', 'demos')
+const demoPath = path.resolve('demos')
 const downloadsPath = path.join('./', 'downloads')
 
 //bin executable


### PR DESCRIPTION
Fixes to prevent the demoPath 'no such file or directory' error upon initial install - 

- changed the default demoPath to path.resolve('demos')  - This is the absolute path of the Odamex-Spawner install + /demos.  This might be useful for the other default paths as well (bin, wad, downloads paths)
- demoparser catches the 'no such file or directory' error now for the default demoPath only, and will create the directory
- 'Loading...' no longer spins if the demoPath folder has 0 demos

- Browse button on Demo/WAD settings will no longer update the paths to NULL if you press cancel