### PR TITLE
Additions to extract the Odamex.dmg versions for MacOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,6 +1989,16 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -3741,6 +3751,11 @@
         "path-type": "^3.0.0"
       }
     },
+    "dmg": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dmg/-/dmg-0.1.0.tgz",
+      "integrity": "sha1-s46iEH9vCwcEQrv3mb/E8q7apfg="
+    },
     "dmg-builder": {
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-6.7.2.tgz",
@@ -4581,6 +4596,26 @@
         }
       }
     },
+    "extract-dmg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extract-dmg/-/extract-dmg-1.0.0.tgz",
+      "integrity": "sha512-MJrst/yHa5Z/GSfYd4oXnJmIbL5uhpRvzrxosgiuF3QNPT6AH8FUKd/tzuEk5x9CKWjVTpCUPiuvZYnjZ76ovQ==",
+      "requires": {
+        "dmg": "^0.1.0",
+        "file-ext": "^1.0.0",
+        "fs-extra": "^8.1.0",
+        "get-ext": "^1.0.2",
+        "ow": "^0.16.0",
+        "pify": "^5.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+        }
+      }
+    },
     "extract-zip": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
@@ -4651,6 +4686,15 @@
         "object-assign": "^4.1.0"
       }
     },
+    "file-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-ext/-/file-ext-1.0.0.tgz",
+      "integrity": "sha512-/gd7NKKmNageT+bw5l+/GFxwIPcvoO0re6yM71hbxlwthdeuNOlegTN/FR7GVj1ZZQFATwoVAz0n4a0dlmwzVQ==",
+      "requires": {
+        "get-ext": "^1.0.2",
+        "ow": "^0.16.0"
+      }
+    },
     "file-loader": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
@@ -4672,6 +4716,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -4820,7 +4871,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -4930,6 +4980,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-ext": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-ext/-/get-ext-1.0.2.tgz",
+      "integrity": "sha1-/OiW0MxM1hXs58E6Dr1V5lJwBW0="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -6175,7 +6230,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -7477,6 +7531,21 @@
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
+      }
+    },
+    "ow": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.16.0.tgz",
+      "integrity": "sha512-pJAkOEbRT7vhJZlkyKp/rQKR4YQ3qqdek6f3MnHMs7MRBKm5RfZq6GiLnqMRbQeYTwhMFXsTFuyhDrFuPu+yFQ==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+        }
       }
     },
     "p-cancelable": {
@@ -10138,8 +10207,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -10706,6 +10774,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -10941,6 +11010,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "axios": "^0.21.1",
     "bootstrap-css-only": "^4.3.1",
     "bootstrap-vue": "^2.1.0",
+    "extract-dmg": "^1.0.0",
     "font-awesome": "^4.7.0",
     "unzipper": "^0.10.8",
     "vue": "^2.5.16",

--- a/src/renderer/components/settings/ClientVersions.vue
+++ b/src/renderer/components/settings/ClientVersions.vue
@@ -50,6 +50,7 @@ import unzipper from 'unzipper'
 import folders from '@/libs/folders.js'
 
 const readdirAsync = util.promisify(fs.readdir)
+const extractDmg = require('extract-dmg');
 
 let parseXML = require('xml2js').parseString
 
@@ -96,9 +97,9 @@ export default {
               }else if(os.platform() == 'darwin' && path.includes("_macos")){ //macos
 
                   this.repoBins.push({
-                    name: 'Odamex ' + filepath.replace('macos.dmg', ''),
+                    name: 'Odamex ' + filepath.replace('_macos.dmg', ''),
                     filename: filepath,
-                    foldername: filepath.replace('macos.dmg', ''),
+                    foldername: filepath.replace('_macos.dmg', ''),
                     url: path,
                     kind: 'official'
                   })
@@ -126,9 +127,9 @@ export default {
               }else if(os.platform() == 'darwin' && path.includes("_macos")){ //macos
 
                   this.repoBins.push({
-                    name: 'Odamex ' + filepath.replace('macos.dmg', ''),
+                    name: 'Odamex ' + filepath.replace('_macos.dmg', ''),
                     filename: filepath,
-                    foldername: filepath.replace('macos.dmg', ''),
+                    foldername: filepath.replace('_macos.dmg', ''),
                     url: path,
                     kind: 'experimental'
                   })
@@ -221,10 +222,8 @@ export default {
           
           resp.pipe(file)
           .on('finish', () => {
-            
-            this.extractBin(binObject) //unextract zip file (for windows binaries)
-            
-            //TODO: install macOS binary 
+
+            this.extractBin(binObject) //unextract zip file 
 
           })
 
@@ -243,23 +242,39 @@ export default {
 
         folders.checkDirectory(newBinPath)
 
-        fs.createReadStream(downloadPath)
+        if(os.platform() == 'darwin'){
 
-        .pipe(unzipper.Extract({ path: newBinPath}))
-
-        .on('close', () => {
+          await extractDmg(downloadPath, newBinPath)
 
           //set download state
-          let indexFound = this.mergedBins.findIndex(binFromList => binFromList.url == binObject.url)
+          var indexFound = this.mergedBins.findIndex(binFromList => binFromList.url == binObject.url)
 
           if(indexFound != -1){
-            this.$set(this.mergedBins[indexFound], '_isDownloading', false)
-            this.$set(this.mergedBins[indexFound], 'downloaded', true)
-          }
+              this.$set(this.mergedBins[indexFound], '_isDownloading', false)
+              this.$set(this.mergedBins[indexFound], 'downloaded', true)
+            }
 
-          this.$store.dispatch('refreshBINSList') //refresh select version in navbar
+        } else {
 
-        })
+          fs.createReadStream(downloadPath)
+
+          .pipe(unzipper.Extract({ path: newBinPath}))
+
+          .on('close', () => {
+
+            //set download state
+            var indexFound = this.mergedBins.findIndex(binFromList => binFromList.url == binObject.url)
+
+            if(indexFound != -1){
+              this.$set(this.mergedBins[indexFound], '_isDownloading', false)
+              this.$set(this.mergedBins[indexFound], 'downloaded', true)
+            }
+
+          })
+
+        }
+
+        this.$store.dispatch('refreshBINSList') //refresh select version in navbar
 
       }catch(e){
         console.error(e)

--- a/src/renderer/components/settings/ClientVersions.vue
+++ b/src/renderer/components/settings/ClientVersions.vue
@@ -242,7 +242,7 @@ export default {
 
         folders.checkDirectory(newBinPath)
 
-        if(os.platform() == 'darwin'){
+        if(os.platform() == 'darwin'){ //macos
 
           await extractDmg(downloadPath, newBinPath)
 
@@ -254,7 +254,7 @@ export default {
               this.$set(this.mergedBins[indexFound], 'downloaded', true)
             }
 
-        } else {
+        } else { //windows
 
           fs.createReadStream(downloadPath)
 

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -5,6 +5,7 @@ import VuexPersist from 'vuex-persistfile'
 import fs from 'fs'
 import util from 'util'
 import {lstatSync} from 'fs'
+import os from 'os'
 
 const readdirAsync = util.promisify(fs.readdir)
 
@@ -84,7 +85,12 @@ export default new Vuex.Store({
       finalParams.push("-config")
       finalParams.push("./odamexbinconfig.cfg")
 
-      let fullBinPath = path.join(context.state.binPath, context.state.defaultBinPath, 'odamex.exe')
+      if (os.platform() == 'darwin'){
+        var fullBinPath = path.join(context.state.binPath, context.state.defaultBinPath, 'Odamex/odamex.app/Contents/MacOS/odamex')
+      } else {
+        var fullBinPath = path.join(context.state.binPath, context.state.defaultBinPath, 'odamex.exe')
+      }
+
       child(fullBinPath, finalParams, function(err, data){})
 
     },


### PR DESCRIPTION
Found a nice little package extract-dmg which seems to get the job done.  Updated the extractBin method of ClientVersions.vue to handle extracting for mac.  Also updated the connecttoServer action in index.js to handle launching from Mac.  Tested on Mac Sierra 10.12